### PR TITLE
Change log -	Module 04: Lab A: Deploying Software-Defined Networking

### DIFF
--- a/Instructions/Labs/LAB_04A_Deploying_Software-Defined_Networking (1).md
+++ b/Instructions/Labs/LAB_04A_Deploying_Software-Defined_Networking (1).md
@@ -119,7 +119,8 @@ The main tasks for this exercise are as follows:
 
 ### Task 2: Deploy the SDN infrastructure VMs
 
-> **Note**: Make sure all of the VMs you provisioned in the previous task are running and that their operating system has been activated before you proceed to the next task. If that is not the case, start all of the VMs, sign in to each of them  using the **CORP\\LabAdmin** username and **LS1setup!** password and, from the elevated Command Prompt, run `slmgr -rearm`. The **DC** VM will require you to run `slmgr -rearm` and be restarted.
+   > **Note**: Sign in to the **DC** VM using the **CORP\\LabAdmin** username and **LS1setup!** password, run `slmgr -rearm` and restart it.
+
 1. On the lab VM, use the Hyper-V Manager console to connect to the **SDNExpress2019-Management** VM. When prompted to sign in, provide the **CORP\\LabAdmin** username and **LS1setup!** password.
 1. Within the console session to the **SDNExpress2019-Management** VM, start Windows PowerShell ISE as Administrator and run the following script to expand the size of drive **C** of the VMs that will host the SDN environment:
 


### PR DESCRIPTION
o	Ex 1, Task 2: I verified that only the **DC** VM will require you to run `slmgr -rearm` and be restarted.  I did not remove the part of the note that says to do slmgr -rearm on all the VMs. This note can simply say “Sign in to the **DC** VM using the CORP\LabAdmin username and LS1setup! password, run `slmgr -rearm` and restart it.”

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-